### PR TITLE
fix(url): update html links to our colleagues' blog posts

### DIFF
--- a/_posts/2021-11-18-hsdo.md
+++ b/_posts/2021-11-18-hsdo.md
@@ -13,7 +13,7 @@ language: en
 AWS ALB & NLB currently supports Round-Robin (RR) and Least Outstanding Requests (LOR) balancing algorithms. But what happens when you try to load balance cache servers with these algorithms? How to implement an effective cache in Cloud at scale?
 
 # Context
-At Bedrock we use both ALB & NLB for different use-cases (like [in front of our Kubernetes clusters](https://tech.bedrockstreaming.com/Three-years-running-kubernetes-on-production-at-Bedrock/)) in our platforms. For our last VOD platform, we needed to be able to load balance heavy content (videos) to our cache servers. We knew that the balancing algorithm was a key factor for our cache in Cloud at scale, and that ALB & NLB won’t be sufficient to achieve our goals. 
+At Bedrock we use both ALB & NLB for different use-cases (like [in front of our Kubernetes clusters](https://tech.bedrockstreaming.com/2020/12/08/Three-years-running-kubernetes-on-production-at-Bedrock.html)) in our platforms. For our last VOD platform, we needed to be able to load balance heavy content (videos) to our cache servers. We knew that the balancing algorithm was a key factor for our cache in Cloud at scale, and that ALB & NLB won’t be sufficient to achieve our goals. 
 
 # Balancing algorithms
 

--- a/_posts/2021-12-15-scaling-bedrock-video-delivery-to-50-million-users.md
+++ b/_posts/2021-12-15-scaling-bedrock-video-delivery-to-50-million-users.md
@@ -143,7 +143,7 @@ To use the cache as much as possible, we need an adapted load balancing method: 
 ![Consistent Hashing is an ideal method for caches](/images/posts/2021-11-18-hsdo/image10.png)
 <center><i>Consistent Hashing is an ideal method for caches</i></center>
 
-Last two images are from [our recent blog post about doing advanced load balancing at AWS](https://tech.bedrockstreaming.com/hsdo/).
+Last two images are from [our recent blog post about doing advanced load balancing at AWS](https://tech.bedrockstreaming.com/2021/11/18/hsdo.html).
 
 With Consistent Hashing, we can send all requests for the same video to the same cache server. This would optimize the local Nginx cache and reduce S3 costs.
 
@@ -166,7 +166,7 @@ HAProxy is running on EC2 instances, in a dedicated AutoScalingGroup. As with th
 To send requests to USP origin, HAProxy needs to know all the healthy EC2 instances running in their AutoScalingGroup.  
 We started by using Consul, to automatically populate our HAProxy backend with these USP servers.
 
-See the [dedicated blog post](https://tech.bedrockstreaming.com/hsdo/) to know why we preferred to develop a tool dedicated to this task, which we called HAProxy Service Discovery Orchestrator (HSDO).
+See the [dedicated blog post](https://tech.bedrockstreaming.com/2021/11/18/hsdo.html) to know why we preferred to develop a tool dedicated to this task, which we called HAProxy Service Discovery Orchestrator (HSDO).
 
 
 ### EC2 costs are reduced by using only Spot instances <a name="EC2SpotInstances"></a>

--- a/_posts/2022-03-08-cloudfront-web-streaming-platform-part-1.md
+++ b/_posts/2022-03-08-cloudfront-web-streaming-platform-part-1.md
@@ -16,7 +16,7 @@ Millions of users connect every month to watch their live, replay or the series 
 The broadcasting of sports events such as the Euro 2020 soccer tournament represents a real technical challenge when it comes to maintaining the stability and performance of such a platform.
 
 The web application works in SSR (Server Side Rendering) mode: we have NodeJS Express servers returning pre-rendered HTML pages.
-We made [this choice several years ago](https://tech.bedrockstreaming.com/spa-mode-isomorphism-js/), for two reasons: SEO and to improve the first display time on slow devices.
+We made [this choice several years ago](https://tech.bedrockstreaming.com/2017/05/17/spa-mode-isomorphism-js.html), for two reasons: SEO and to improve the first display time on slow devices.
 In addition to the HTML pages, the web platform is also a huge collection of assets that allow the website to function: Javascript bundles, CSS, images, manifests.
 
 Today our customers have users distributed over a large part of the globe.


### PR DESCRIPTION
# Why?

Following the set up of the new theme for Bedrock tech blog site, some HTML links are dead.