### PR TITLE
feat: add figure and figcaption element

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gemspec
 gem "jekyll-redirect-from", "~> 0.16.0"
 gem "jekyll-twitter-plugin", "~> 2.1.0"
 gem "webrick", "~> 1.7"
+gem 'jekyll-figure', "~> 0.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       terminal-table (~> 2.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-figure (0.1.0)
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
@@ -81,6 +82,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  jekyll-figure (~> 0.1.0)
   jekyll-redirect-from (~> 0.16.0)
   jekyll-twitter-plugin (~> 2.1.0)
   type-on-strap!

--- a/_config.yml
+++ b/_config.yml
@@ -44,8 +44,11 @@ paginate_path: "/blog/page:num"
 # BUILD SETTINGS
 sass:
   style: compressed
-plugins: [jekyll-paginate, jekyll-seo-tag, jekyll-feed, jekyll-redirect-from, jekyll-twitter-plugin]
+plugins: [jekyll-paginate, jekyll-seo-tag, jekyll-feed, jekyll-redirect-from, jekyll-twitter-plugin, jekyll-figure]
 exclude: [".jekyll-cache", ".jekyll-metadata", ".idea", "vendor/*", "assets/node_modules/*"]
 
 # theme: type-on-strap                                  # if using the theme as a jekyll theme gem
 remote_theme: sylhare/Type-on-Strap                     # If using as a remote_theme in github
+
+jekyll-figure:
+  paragraphs: false

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -112,6 +112,13 @@ header {
     padding-bottom: 0;
   }
 
+  .figure {
+    font-style: italic;
+    text-align:center;
+    color : rgb(128, 128, 128);
+    font-size: 0.9em;
+  }
+
   footer {
     @extend %padding-post;
     padding-top: 0;


### PR DESCRIPTION
add [jekyll-figure](https://www.rubydoc.info/gems/jekyll-figure/0.1.0) Gem that can generate figure element with this syntax : 

```
{% figure caption:"Rejoignez-nos équipes et venez vivre les prochaines conférences avec nous l’an prochain" class:"figure" %}
!["KubeCon 2022 day1"](/images/posts/2022-06-13-kubecon-2022/end-part1.jpg)
{% endfigure %}
```

create a css content associated to the `figure` class for a better render :  
![Capture d’écran 2022-06-13 à 08 59 29](https://user-images.githubusercontent.com/50320627/173297472-78bd365c-5f27-4f36-ae1d-33cff8caa1ce.png)