### PR TITLE
fix: use correct link for tags in post

### DIFF
--- a/_includes/default/tags_list.liquid
+++ b/_includes/default/tags_list.liquid
@@ -10,7 +10,7 @@
       {% endif %}
 
       {% for tag in tags %}
-        <li><a class="button" href="#{{ tag | cgi_escape }}">
+        <li><a class="button" href="/tags/#{{ tag | cgi_escape }}">
           <p><i class="fas fa-tag fa-fw fa-sm"></i> {{ tag }}</p>
         </a></li>
       {% endfor %}


### PR DESCRIPTION
Fix #313 

Link for post are now functional :) 