### PR TITLE
Revert "feat: add figure and figcaption element"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ gemspec
 gem "jekyll-redirect-from", "~> 0.16.0"
 gem "jekyll-twitter-plugin", "~> 2.1.0"
 gem "webrick", "~> 1.7"
-gem 'jekyll-figure', "~> 0.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
       terminal-table (~> 2.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-figure (0.1.0)
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
@@ -82,7 +81,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll-figure (~> 0.1.0)
   jekyll-redirect-from (~> 0.16.0)
   jekyll-twitter-plugin (~> 2.1.0)
   type-on-strap!

--- a/_config.yml
+++ b/_config.yml
@@ -44,11 +44,8 @@ paginate_path: "/blog/page:num"
 # BUILD SETTINGS
 sass:
   style: compressed
-plugins: [jekyll-paginate, jekyll-seo-tag, jekyll-feed, jekyll-redirect-from, jekyll-twitter-plugin, jekyll-figure]
+plugins: [jekyll-paginate, jekyll-seo-tag, jekyll-feed, jekyll-redirect-from, jekyll-twitter-plugin]
 exclude: [".jekyll-cache", ".jekyll-metadata", ".idea", "vendor/*", "assets/node_modules/*"]
 
 # theme: type-on-strap                                  # if using the theme as a jekyll theme gem
 remote_theme: sylhare/Type-on-Strap                     # If using as a remote_theme in github
-
-jekyll-figure:
-  paragraphs: false

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -112,13 +112,6 @@ header {
     padding-bottom: 0;
   }
 
-  .figure {
-    font-style: italic;
-    text-align:center;
-    color : rgb(128, 128, 128);
-    font-size: 0.9em;
-  }
-
   footer {
     @extend %padding-post;
     padding-top: 0;


### PR DESCRIPTION
Reverts BedrockStreaming/tech.bedrockstreaming.com#324

`jekill-figure` plugin isn't supported by github-pages :( 

https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins