### PR TITLE
fix: social links in footer

### DIFF
--- a/_data/icons.yml
+++ b/_data/icons.yml
@@ -6,13 +6,13 @@ calendly:
 dribbble:
 facebook:
 flickr:
-github: sylhare
+github: BedrockStreaming/tech.bedrockstreaming.com
 gitlab:
 google-scholar:   # e.g. "WXAAOb0AAAAJ"
 instagram:
 hacker-news:
 keybase:
-linkedin:
+linkedin: bedrock-streaming
 mail:             # e.g. "sam@mail.com"
 map:              # e.g. "34.0886/-118.3191"
 mastodon:         # e.g. "fostodon.org/@sam"
@@ -30,7 +30,7 @@ steam:
 telegram:
 tumblr:
 twitch:
-twitter:
+twitter: Bedrock_Tech
 vimeo:
 vk:
 wordpress:

--- a/_data/icons.yml
+++ b/_data/icons.yml
@@ -6,7 +6,7 @@ calendly:
 dribbble:
 facebook:
 flickr:
-github: BedrockStreaming/tech.bedrockstreaming.com
+github: BedrockStreaming
 gitlab:
 google-scholar:   # e.g. "WXAAOb0AAAAJ"
 instagram:

--- a/_data/icons_builder.yml
+++ b/_data/icons_builder.yml
@@ -27,7 +27,7 @@ hacker-news:
 keybase:
   pre: "https://keybase.io/"
 linkedin:
-  pre: "https://www.linkedin.com/in/"
+  pre: "https://www.linkedin.com/company/"
 mail:
   pre: "mailto:"
   icon: "fas fa-envelope"


### PR DESCRIPTION
## Why

@kennydee found out that link in footer were not working and targetting correct account

## How

- change github to the blog repository
- define twitter to the Bedrock_tech account
- define linkedin to the official page
