### PR TITLE
feat: start the list of conferences

### DIFF
--- a/pages/meetup-conference.md
+++ b/pages/meetup-conference.md
@@ -6,7 +6,7 @@ permalink: /meetups/
 feature-img: "images/travel.jpg"
 ---
 
-Bedrock through its actions sponsors events in France, hosts Meetup and conferences in its auditorium.  On many occasions, Bedrock members have even had the opportunity to give conferences in France or abroad.
+Bedrock through its actions, sponsors events in France, hosts Meetup and conferences in its auditorium. Each of those events is an opportunity for Bedrock members to give conferences in France or abroad.
 
 _⭐ sponsored by Bedrock_
 _🏠 hosted by Bedrock_

--- a/pages/meetup-conference.md
+++ b/pages/meetup-conference.md
@@ -26,6 +26,24 @@ _🏠 hosted by Bedrock_
   - Préparez et donnez votre premier talk [Pascal MARTIN](https://twitter.com/pascal_martin)
 - 04/04: [LyonJS Meetup](https://www.meetup.com/fr-FR/lyonjs/events/284549533/)
   - Comment faire un trailer vidéo qui déchire avec des technos web ? [Mickaël Alves](https://twitter.com/CruuzAzul), [Antoine Caron](https://twitter.com/Slashgear_)
+- 05/02: [Snowcamp 2022](https://snowcamp.io/fr/)
+  - Comment ne pas jeter son application Frontend tous les deux ans ? [Florent Dubost](https://twitter.com/fooragnak), [Antoine Caron](https://twitter.com/Slashgear_)
+
+### 2021
+
+- 10/11: [Devfest Nantes](https://devfest2021.gdgnantes.com/sessions/_%EF%B8%8F_vite_%EF%B8%8Fthe_webpack_killer/)
+  - ⚡️ Vite ⚡️ the Webpack killer [Mathieu Mure](https://twitter.com/mathieumure), [Antoine Caron](https://twitter.com/Slashgear_)
+- 08/09: [JUG Summer Camp](https://www.jugsummercamp.org/edition/12/presentations/QYeD36ff9h4A8v243Hu3)
+  - ⚡️ Vite ⚡️ the Webpack killer [Mathieu Mure](https://twitter.com/mathieumure), [Antoine Caron](https://twitter.com/Slashgear_)
+
+### 2020
+
+- 07/09: [Paris Web](https://www.paris-web.fr/2019/ateliers/webpack-workshop.php)
+  - Webpack Workshop [Antoine Caron](https://twitter.com/Slashgear_)
+- 10/06: [LyonJS Meetup](https://www.meetup.com/fr-FR/LyonJS/events/278441866/)
+  - ⚡️ Vite ⚡️ the Webpack killer [Mathieu Mure](https://twitter.com/mathieumure), [Antoine Caron](https://twitter.com/Slashgear_)
+- 22/01: [Snowcamp 2020](https://snowcamp.io/)
+  - Webpack Workshop [Antoine Caron](https://twitter.com/Slashgear_)
 
 ## Replays
 

--- a/pages/meetup-conference.md
+++ b/pages/meetup-conference.md
@@ -16,7 +16,7 @@ _🏠 hosted by Bedrock_
   - Migration progressive vers Redux Toolkit [Maxime Blanc](https://maximeblanc.fr)
   - Comment ne pas jeter son application Frontend tous les deux ans ? [Florent Dubost](https://twitter.com/fooragnak), [Antoine Caron](https://twitter.com/Slashgear_) 
 - 15/05: ⭐️ 🏠 [Docker meetup](https://www.meetup.com/fr-FR/docker-lyon/events/285057478/)
-  - Open Policy Agent avec KICS de chez Checkmarx Jean-Yves Camier
+  - Open Policy Agent avec KICS de chez Checkmarx [Jean-Yves Camier](https://twitter.com/Saaraahka)
   - You build it, you run it - [Jerome Foray](https://twitter.com/meroje01)
 - 21/04: [Devoxx France](https://www.devoxx.fr/)
   - ⚡️ Vite ⚡️ the Webpack killer [Mathieu Mure](https://twitter.com/mathieumure), [Antoine Caron](https://twitter.com/Slashgear_)

--- a/pages/meetup-conference.md
+++ b/pages/meetup-conference.md
@@ -6,4 +6,23 @@ permalink: /meetups/
 feature-img: "images/travel.jpg"
 ---
 
-This page presents a set of talks and conferences given during public events in France and abroad.
+Bedrock through its actions sponsors events in France, hosts Meetup and conferences in its auditorium.  On many occasions, Bedrock members have even had the opportunity to give conferences in France or abroad.
+
+_⭐ sponsored by Bedrock_
+_🏠 hosted by Bedrock_
+
+### 2022
+- 08/06: ⭐️ 🏠 [LyonJS Meetup](https://www.meetup.com/fr-FR/lyonjs/events/285497869/) 
+  - Migration progressive vers Redux Toolkit [Maxime Blanc](https://maximeblanc.fr)
+  - Comment ne pas jeter son application Frontend tous les deux ans ? [Florent Dubost](https://twitter.com/fooragnak), [Antoine Caron](https://twitter.com/Slashgear_) 
+- 15/05: ⭐️ 🏠 [Docker meetup](https://www.meetup.com/fr-FR/docker-lyon/events/285057478/)
+  - Open Policy Agent avec KICS de chez Checkmarx Jean-Yves Camier
+  - You build it, you run it - [Jerome Foray](https://twitter.com/meroje01)
+- 21/04: [Devoxx France](https://www.devoxx.fr/)
+  - ⚡️ Vite ⚡️ the Webpack killer [Mathieu Mure](https://twitter.com/mathieumure), [Antoine Caron](https://twitter.com/Slashgear_)
+- 04/04: [LyonJS Meetup](https://www.meetup.com/fr-FR/lyonjs/events/284549533/)
+  - Comment faire un trailer vidéo qui déchire avec des technos web ? [Mickaël Alves](https://twitter.com/CruuzAzul), [Antoine Caron](https://twitter.com/Slashgear_)
+
+## Replays
+
+Here is the list of the replay of talks given during these events:

--- a/pages/meetup-conference.md
+++ b/pages/meetup-conference.md
@@ -20,6 +20,10 @@ _🏠 hosted by Bedrock_
   - You build it, you run it - [Jerome Foray](https://twitter.com/meroje01)
 - 21/04: [Devoxx France](https://www.devoxx.fr/)
   - ⚡️ Vite ⚡️ the Webpack killer [Mathieu Mure](https://twitter.com/mathieumure), [Antoine Caron](https://twitter.com/Slashgear_)
+- 12/04: [AWS Summit Paris](https://aws.amazon.com/fr/events/summits/paris/)
+  - Transformer le load balancing pour optimiser le cache : objectif 50 millions d'utilisateurs [Vincent GALLISSOT](https://twitter.com/vgallissot)
+  - Êtes-vous bien architecturé ? [Pascal MARTIN](https://twitter.com/pascal_martin)
+  - Préparez et donnez votre premier talk [Pascal MARTIN](https://twitter.com/pascal_martin)
 - 04/04: [LyonJS Meetup](https://www.meetup.com/fr-FR/lyonjs/events/284549533/)
   - Comment faire un trailer vidéo qui déchire avec des technos web ? [Mickaël Alves](https://twitter.com/CruuzAzul), [Antoine Caron](https://twitter.com/Slashgear_)
 


### PR DESCRIPTION
@kennydee Asked me if it was possible to add somewhere on the blog the list of talks given by bedrock employee.
Here it is.
I just added 2022 event I have been aware of.
I will ask for contributions for past events.