### PR TITLE
GHA workflow to deploy, to use same workflow than dev one

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,13 +1,16 @@
 name: Continous Integration
 
 on:
+  # On merge master
   push:
     branches: [master]
+  # Check that the static website is buildable for every PR
   pull_request:
     branches: [master]
 
 jobs:
   build:
+    name: 'Build 📦'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,3 +20,22 @@ jobs:
       - run: gem install bundler
       - run: bundle install --jobs 4 --retry 3
       - run: bundle exec jekyll build
+
+  deploy:
+    needs: build
+    name: 'Deploy 🚀'
+    runs-on: ubuntu-latest
+    # Deploy only master branch
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: ./_site
+      - uses: JamesIves/github-pages-deploy-action@v4.3.4
+        name: 'Deploy 🚀'
+        with:
+          branch: master
+          folder: _site
+          clean: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,14 +28,8 @@ jobs:
     # Deploy only master branch
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: ./_site
       - uses: JamesIves/github-pages-deploy-action@v4.3.4
         name: 'Deploy 🚀'
         with:
-          branch: master
           folder: _site
           clean: true


### PR DESCRIPTION
Previously, deploy workflow was the default one of Github page.

But, this workflow is different as the used one for dev and in continuous integration testing, especially on the Jekyll version used.

With this PR, the deploy workflow will use the static site builded in the "Build" step, and will use same process than the development process.