### PR TITLE
feat: change heading style for reading purpose

### DIFF
--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -37,7 +37,6 @@ h6 {
   font-family: $font-family-headings;
   line-height: 1.3;
   margin: 0.67em 0;
-  text-transform: uppercase;
 
   a {
     color: var(--text);

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -43,10 +43,10 @@ html, html[data-theme="light"] {
   --text: #262626;
   --h1: #fd4d26; // headers
   --h2: #fd4d26;
-  --h3: #fd4d26;
-  --h4: #fd4d26;
-  --h5: #fd4d26;
-  --h6: #fd4d26;
+  --h3: #262626;
+  --h4: #262626;
+  --h5: #262626;
+  --h6: #262626;
   --border: rgba(0, 0, 0, 0.2);
 }
 
@@ -65,10 +65,10 @@ html[data-theme="dark"] {
   --text: #cdd9e5; // text
   --h1: #fd4d26; // headers
   --h2: #fd4d26;
-  --h3: #fd4d26;
-  --h4: #fd4d26;
-  --h5: #fd4d26;
-  --h6: #fd4d26;
+  --h3: #ff7d5f;
+  --h4: #ff7d5f;
+  --h5: #fc937c;
+  --h6: #fc937c;
   --border: rgba(255, 255, 255, 0.5); // border
   --cusdis--color-text-default: var(--text);
   --cusdis--color-comment-username-text: var(--link);


### PR DESCRIPTION
## Why

When I follow bedrock assets style in the PR #304, I was asked to put all the titles in uppercase.
At first this could be a good idea.

Using capslock heading are really bad for people to read.

[You can read more about that in this article](https://readabilityguidelines.co.uk/grammar-points/capital-letters/)

# How

- drop uppercase style on headings 
- use different color in h3 -> h6 in order to help readers understand that the level changed