### PR TITLE
feat: remove about page

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -1,8 +1,0 @@
----
-layout: page
-title: About
-permalink: /about/
-feature-img: "images/travel.jpg"
-tags: [Page]
----
-This blog shows the work from the [Bedrock](https://bedrockstreaming.com/) technical team (former M6Web / M6 Distribution) and the [open source contributions](/oss/) done by the team.


### PR DESCRIPTION
About page is so empty, why not removing it ?