### PR TITLE
fix: non-interpreted link

### DIFF
--- a/_posts/2022-09-01-kubernetes-prescaling-we-open-source-our-solution.md
+++ b/_posts/2022-09-01-kubernetes-prescaling-we-open-source-our-solution.md
@@ -24,7 +24,7 @@ We also wanted to simplify the project. In the first versions, we had two bricks
 
 ## Here we go, we open source it
 
-The great moment has come. Our prescaling solution is now available on GitHub in its alpha version: https://github.com/BedrockStreaming/prescaling-exporter.
+The great moment has come. Our prescaling solution is now available on GitHub in its alpha version: [https://github.com/BedrockStreaming/prescaling-exporter](https://github.com/BedrockStreaming/prescaling-exporter).
 
 This is the version we currently use in all our clusters. Let's quickly see how to implement the solution (you can find more details in the repo README).
 


### PR DESCRIPTION
## Why 

A link in the article "Prescaling pods in Kubernetes, we open source our solution" is not interpreted. 
