### PR TITLE
Keep HTML in excerpts on homepage

### DIFF
--- a/_includes/blog/blog.liquid
+++ b/_includes/blog/blog.liquid
@@ -25,7 +25,7 @@
                   {% if site.excerpt == "truncate" %}
                      {{ post.content | strip_html | truncate: '250' | escape }}
                   {% else %}
-                     {{ post.excerpt | strip_html | escape }}
+                     {{ post.excerpt }}
                   {% endif %}
               </div>
           {% endif %}

--- a/_posts/2022-11-15-onboarding-revue-code.md
+++ b/_posts/2022-11-15-onboarding-revue-code.md
@@ -9,8 +9,6 @@ color: rgb(251,87,66)
 language: fr
 ---
 
-# Facilitez l’onboarding de vos collègues grâce à la revue de code!
-
 Au sein des équipes de développement, une activité bien connue est celle de la revue de code, et 
 plus 
 précisément de la **revue du delta du code**. Il s'agit de l'inspection par nos 


### PR DESCRIPTION
Les extraits d'articles, sur la page d'accueil du blog, sont *moches*.

Voici les deux derniers, aujourd'hui :
<img width="1273" alt="Capture d’écran 2022-11-29 à 15 14 22" src="https://user-images.githubusercontent.com/193481/204552254-0b4b6e4b-f45c-4c28-bbf0-cb673161c6de.png">

Je me dis que ça rendrait bien mieux si on conservait le HTML. Les paragraphes, notamment. Mais aussi les liens (il y en a dans l'excerpt d'un article plus bas).

Sur les deux mêmes articles, ça donnerait ceci (screenshoté depuis mon poste, mais la preview devrait bientôt arriver ;-)) :
<img width="1273" alt="Capture d’écran 2022-11-29 à 15 15 24" src="https://user-images.githubusercontent.com/193481/204552601-4138bbcd-4002-4201-b590-c87ccb867ce8.png">

Je suis remonté sur quelques (seulement quelques unes, j'avoue) pages d'historique, ça me semble mieux "maintenant" que "avant"… Qu'en pensez-vous ?