### PR TITLE
fix(template): fix multiple authors not showing up

### DIFF
--- a/_includes/blog/blog.liquid
+++ b/_includes/blog/blog.liquid
@@ -18,7 +18,7 @@
                 {{ post.title }}
               </a>
             </h1>
-            {% include blog/post_info.liquid author=post.author date=post.date %}
+            {% include blog/post_info.liquid authors=post.author date=post.date %}
           </header>
           {% if site.excerpt or site.theme_settings.excerpt %}
               <div class="excerpt">

--- a/_includes/blog/post_info.liquid
+++ b/_includes/blog/post_info.liquid
@@ -7,9 +7,9 @@
   {% if author.avatar  %}
     <img alt="Author's avatar" src="{{ author.avatar | relative_url }}">
   {% endif %}
-  <p class="meta">
+  <span class="meta">
     {% if author.name %}{{ author.name }} -&#160;{% endif %}
-  </p>
+  </span>
   {%- if author.url -%}</a>{%- endif -%}
 {% endfor %}
   <p class="meta">

--- a/_includes/blog/post_info.liquid
+++ b/_includes/blog/post_info.liquid
@@ -1,15 +1,21 @@
-{% assign author = site.data.authors[include.author] %}
+<div class="post-info">
+{% for authorId in include.authors %}
+{% assign author = site.data.authors[authorId] %}
 {% assign date = include.date | default: "today" | date: "%B %-d, %Y" %}
 
-<div class="post-info">
   {%- if author.url -%}<a href="{{ author.url | relative_url }}" target="_blank" rel="noopener">{%- endif -%}
-    {% if author.avatar  %}
-      <img alt="Author's avatar" src="{{ author.avatar | relative_url }}">
-    {% endif %}
-    <p class="meta">
-      {% if author.name %}{{ author.name }} - {% endif %}
-      {% assign x = date | date: "%m" | minus: 1 %}
-      {{ site.data.language.str_months[x] | default: date | date: "%B" }} {{ date | date: "%d, %Y" }}
-    </p>
+  {% if author.avatar  %}
+    <img alt="Author's avatar" src="{{ author.avatar | relative_url }}">
+  {% endif %}
+  <p class="meta">
+    {% if author.name %}{{ author.name }} -&#160;{% endif %}
+  </p>
   {%- if author.url -%}</a>{%- endif -%}
+{% endfor %}
+  <p class="meta">
+    {% assign x = date | date: "%m" | minus: 1 %}
+    {{ site.data.language.str_months[x] | default: date | date: "%B" }} {{ date | date: "%d, %Y" }}
+  </p>
 </div>
+
+

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -61,7 +61,7 @@ header {
   border-radius: 1em;
   padding-right: 0.5em;
   display: inline-flex;
-
+  flex-wrap: wrap;
   a {
     display: flex;
     align-items: center;


### PR DESCRIPTION
# Why
We want to have a liste of authors whenever multiple persons publish an article.

# How
The first commit make sure multiple authors appears: 
- with my PR :
![image](https://user-images.githubusercontent.com/43119213/225688382-7ef2e6c5-8336-4479-bda7-f9dc1cc9b859.png)
- vs before:
![image](https://user-images.githubusercontent.com/43119213/225688471-7365a9af-2d87-434e-83ff-4a912c2a4deb.png)

The second commit make them appear inline rather than weirdly : 
- looks nice : 
![image](https://user-images.githubusercontent.com/43119213/225699206-717db240-49a1-4451-8789-37ddee7bae58.png)

- looks bad :
![image](https://user-images.githubusercontent.com/43119213/225699350-5a520993-435e-4746-b3f2-d787517d3c6e.png)

Thanks for the reviews :+1: 
