### PR TITLE
fix(home): post list display

### DIFF
--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -75,6 +75,11 @@ header {
     }
   }
 
+  span {
+    display: flex;
+    align-items: center;
+  }
+
   img {
     border-radius: 1em;
     padding: 0;


### PR DESCRIPTION
## Why?
Because post information is displayed in not pretty way.

Before:
![image](https://user-images.githubusercontent.com/64267403/233013868-c596cfc5-bbbb-42a7-84b6-c61b80fedabe.png)

After:
![image](https://user-images.githubusercontent.com/64267403/233016160-9e7d4d4f-ca20-4d0d-9fc5-f82279961b9a.png)
