### PR TITLE
Docke: try, once again, to fix the build + run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,13 @@ bundle exec jekyll serve
 You can use docker to run the tech blog locally.
 
 ```shell
-docker build -t tech-blog .
-docker run -p 8080:8080 tech-blog 
+docker buildx build --platform linux/arm64 -t tech-blog .
+docker run -it -v $(pwd):/var/content:ro -p 8080:8080 -p 35729:35729 tech-blog:latest
 ```
+
+Then open your browser on `http://localhost:8080` to see the blog.
+
+:warning: You may need to change the `docker buildx` command if you are not using an M1 Mac.
 
 ## How to add an article to the blog?
  

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN bundle install
 
 EXPOSE 8080
 EXPOSE 35729
-CMD ["bundle", "exec", "jekyll", "serve", "--source", ".", "--destination", "/var/_site/", "--host", "0.0.0.0", "--port", "8080", "--livereload", "--livereload-port", "35729"]
+CMD ["bundle", "exec", "jekyll", "serve", "--source", ".", "--destination", "/var/_site/", "--host", "0.0.0.0", "--port", "8080", "--livereload", "--livereload-port", "35729", "--disable-disk-cache"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM ruby:3.1
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 COPY type-on-strap.gemspec type-on-strap.gemspec
-RUN gem install jekyll bundler
-RUN bundle install --jobs 4 --retry 3
+
+RUN gem install bundler -v 2.3.16
+RUN gem install jekyll -v 4.3.3
+RUN bundle install
 
 EXPOSE 8080
 EXPOSE 35729

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN gem install bundler -v 2.3.16
 RUN gem install jekyll -v 4.3.3
 RUN bundle install
 
+WORKDIR /var/content
+
 EXPOSE 8080
 EXPOSE 35729
 CMD ["bundle", "exec", "jekyll", "serve", "--source", ".", "--destination", "/var/_site/", "--host", "0.0.0.0", "--port", "8080", "--livereload", "--livereload-port", "35729", "--disable-disk-cache"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN bundle install --jobs 4 --retry 3
 
 EXPOSE 8080
 EXPOSE 35729
-CMD bundle exec jekyll serve --source . --destination /var/_site/ --host 0.0.0.0 --port 8080 --livereload --livereload-port 35729
+CMD ["bundle", "exec", "jekyll", "serve", "--source", ".", "--destination", "/var/_site/", "--host", "0.0.0.0", "--port", "8080", "--livereload", "--livereload-port", "35729"]


### PR DESCRIPTION
The project was not building with docker.

So, once again, trying to fix stuff.
Disclaimer: I'm still very bad with ruby tools 😞 

Basically, what I did:

 * Fix versions of tools, to run the same ones in Docker than we would run locally (as defined in `Gemfile.lock`)
 * Fix syntax in `Dockerfile` for `CMD` -- use the "docker syntax" and not "shell syntax"
 * Disabled jekyll cache (not that useful when running locally + causes permissions issues I didn't want to handle)
 * Updated readme with instructions that work (for me, on a Mac M1)

--- 

_What follows is a summary of changes generated by Copilot, to see how it looks 🙏_

This pull request updates the local development setup for the tech blog by improving the Docker configuration and refining the `Dockerfile`. The most important changes include updating the Docker commands in the `CONTRIBUTING.md` file, modifying the `Dockerfile` to specify gem versions and add a working directory, and enhancing the Jekyll server command with additional options.

### Updates to local development instructions:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L35-R42): Updated Docker commands to use `docker buildx` for ARM64 compatibility and added volume mounting for live content updates. Included a note about potential adjustments for non-M1 Mac users.

### Refinements to the `Dockerfile`:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R15): Specified exact versions for `bundler` (2.3.16) and `jekyll` (4.3.3) to ensure consistent builds. Added a `WORKDIR` at `/var/content` for better organization.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R15): Enhanced the `jekyll serve` command to disable disk caching and use an array format for improved Docker compatibility.