### PR TITLE
Adding a few 2024 conferences for pmartin

### DIFF
--- a/_data/conferences.yaml
+++ b/_data/conferences.yaml
@@ -142,6 +142,13 @@
   eventUrl: https://event.afup.org/afup-day-2023/afup-day-2023-lyon/programme/#4190
   sponsored: true
 
+- title: "Déploiement vers Kubernetes : autonomie et automatisation, mieux que copier-coller du YAML !"
+  date: 2023-06-06
+  author: p_martin
+  eventName: Meetup Café DevOps
+  eventUrl: https://www.youtube.com/live/D8heuC6JKm0?feature=share&t=450
+  sponsored: true
+
 - title: " Améliorons ensemble la doc de #Postgres"
   date: 2023-06-19
   author: s_haim

--- a/_data/conferences.yaml
+++ b/_data/conferences.yaml
@@ -157,6 +157,12 @@
   youtubeId: B665IfwnlU0
   sponsored: true
 
+- title: "Une application résiliente, dans un monde partiellement dégradé"
+  date: 2024-04-17
+  author: p_martin
+  eventName: Devoxx France
+  eventUrl: https://www.youtube.com/watch?v=exk5343fTuM
+
 - title: "Load-testons M6+ pour préparer l’Euro 2024 !"
   date: 2025-04-17
   author: b_colin

--- a/_data/conferences.yaml
+++ b/_data/conferences.yaml
@@ -163,6 +163,12 @@
   eventName: Devoxx France
   eventUrl: https://www.youtube.com/watch?v=exk5343fTuM
 
+- title: "L’aventure d’une requête HTTP — ou le chemin de la vie des devs"
+  date: 2024-10-10
+  author: p_martin
+  eventName: Forum PHP
+  eventUrl: https://www.youtube.com/watch?v=penIr9E0Qbo
+
 - title: "Load-testons M6+ pour préparer l’Euro 2024 !"
   date: 2025-04-17
   author: b_colin


### PR DESCRIPTION
A colleague was asking me a couple of days ago if I could add some of my recent talks to this page.
⇒ I'm doing that :-) 

Notes:

* I didn't create a page for each talk, I only listed them here
* I chose to link to the videos for each talk, instead of link to the event's page. I think it's more useful this way.

Here's how the page looks with this PR:
![2025-05-23 - 15 37 40@2x](https://github.com/user-attachments/assets/0ca8b95a-c4c3-459c-9364-233dde5f67d1)

And here's how it looks online right now: https://tech.bedrockstreaming.com/meetups/

--- 

_What follows is a summary generated by Copilot, and I didn't change any of it._

This pull request updates the `_data/conferences.yaml` file to add new conference talks and their details. The changes primarily include adding three new entries with information about the title, date, author, event name, and event URL.

### Additions of conference talks:

* Added a talk titled "Déploiement vers Kubernetes : autonomie et automatisation, mieux que copier-coller du YAML !" by `p_martin` at the Meetup Café DevOps event on 2023-06-06.
* Added a talk titled "Une application résiliente, dans un monde partiellement dégradé" by `p_martin` at the Devoxx France event on 2024-04-17.
* Added a talk titled "L’aventure d’une requête HTTP — ou le chemin de la vie des devs" by `p_martin` at the Forum PHP event on 2024-10-10.